### PR TITLE
Flutter 1.22.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
     sdk: flutter
   meta: ^1.0.5
   intl: '>=0.15.1 <0.17.0'
-  platform: ^2.0.0
   flutter_plugin_android_lifecycle: ^1.0.2
 
 dev_dependencies:


### PR DESCRIPTION
Because every version of local_auth_device_credentials depends on platform ^2.0.0 and every version of flutter_driver from sdk depends on platform 3.0.0-nullsafety.2, local_auth_device_credentials is incompatible with flutter_driver from sdk.